### PR TITLE
Fixes #4; Firefox Nightly Renders Properly; Chromium Does Not Crash

### DIFF
--- a/js/webvr-manager.js
+++ b/js/webvr-manager.js
@@ -279,10 +279,10 @@ WebVRManager.prototype.getOS = function(osName) {
 
 WebVRManager.prototype.enterVR = function() {
   console.log('Entering VR.');
-  if (this.os != 'iOS') {
-    // Enter fullscreen unless we're on iOS (fullscreen not available).
-    this.effect.setFullScreen(true);
-    // Orientation lock.
+  // Enter fullscreen mode (note: this doesn't work in iOS).
+  this.effect.setFullScreen(true);
+  // Orientation lock.
+  if (screen.orientation) {
     screen.orientation.lock('landscape');
   }
   // Set style on button.
@@ -291,10 +291,10 @@ WebVRManager.prototype.enterVR = function() {
 
 WebVRManager.prototype.exitVR = function() {
   console.log('Exiting VR.');
-  if (this.os != 'iOS') {
-    // Leave fullscreen unless we're on iOS (fullscreen not available).
-    this.effect.setFullScreen(false);
-    // Unlock orientation.
+  // Leave fullscreen mode (note: this doesn't work in iOS).
+  this.effect.setFullScreen(false);
+  // Unlock orientation.
+  if (screen.orientation) {
     screen.orientation.unlock();
   }
   // Relinquish wake lock.

--- a/js/webvr-manager.js
+++ b/js/webvr-manager.js
@@ -279,11 +279,13 @@ WebVRManager.prototype.getOS = function(osName) {
 
 WebVRManager.prototype.enterVR = function() {
   console.log('Entering VR.');
-  // Enter fullscreen mode (note: this doesn't work in iOS).
-  this.effect.setFullScreen(true);
-  // Orientation lock.
-  if (screen.orientation) {
-    screen.orientation.lock('landscape');
+  if (this.os != 'iOS') {
+    // Enter fullscreen mode (note: this doesn't work in iOS).
+    this.effect.setFullScreen(true);
+    // Orientation lock.
+    if (screen.orientation) {
+      screen.orientation.lock('landscape');
+    }
   }
   // Set style on button.
   this.setMode(Modes.IMMERSED);
@@ -291,11 +293,13 @@ WebVRManager.prototype.enterVR = function() {
 
 WebVRManager.prototype.exitVR = function() {
   console.log('Exiting VR.');
-  // Leave fullscreen mode (note: this doesn't work in iOS).
-  this.effect.setFullScreen(false);
-  // Unlock orientation.
-  if (screen.orientation) {
-    screen.orientation.unlock();
+  if (this.os != 'iOS') {
+    // Leave fullscreen mode (note: this doesn't work in iOS).
+    this.effect.setFullScreen(false);
+    // Unlock orientation.
+    if (screen.orientation) {
+      screen.orientation.unlock();
+    }
   }
   // Relinquish wake lock.
   this.releaseWakeLock();


### PR DESCRIPTION
Working off of the `gh-pages` and `git bisect`-ing to a solution, this resolves making Firefox work on `master` in the smallest way. It looks like calling on `screen.orientation` functions without checking to see if it exists first were the issue.

Note that while the `gh-pages` also has this fix, that branch still fails for Chromium. This appears due to a problem with handling SVG in the Chromium build I was using ([Brandon's latest build](https://drive.google.com/uc?id=0BzudLt22BqGRaUplVVU5MmR3Rkk&export=download)).

In breaking out this fix I hope it can help move the boilerplate forward until the reasons for the Chromium errors with SVG could be addressed.

Thanks!
