### PR TITLE
Remove `webkitFilter` to prevent Chromium WebVR build crashout

### DIFF
--- a/js/webvr-manager.js
+++ b/js/webvr-manager.js
@@ -162,7 +162,6 @@ WebVRManager.prototype.setMode = function(mode) {
  */
 WebVRManager.prototype.setContrast = function(percent) {
   var value = Math.floor(percent * 100);
-  this.vrButton.style.webkitFilter = 'contrast(' + value + '%)';
   this.vrButton.style.filter = 'contrast(' + value + '%)';
 };
 


### PR DESCRIPTION
One solution for Issue #6 - this simply removes the crash causing line. SVG icons work in Firefox Nightly and behave the same as in Chrome and Safari, which is simply not show.
