### PR TITLE
added renderer.setPixelRatio

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@ body {
 <script>
 //Setup three.js WebGL renderer
 var renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
 
 // Append the canvas element created by the renderer to document body element.
 document.body.appendChild(renderer.domElement);

--- a/js/VREffect.js
+++ b/js/VREffect.js
@@ -82,8 +82,8 @@ THREE.VREffect = function ( renderer, done ) {
 		var leftEyeTranslation = this.leftEyeTranslation;
 		var rightEyeTranslation = this.rightEyeTranslation;
 		var renderer = this._renderer;
-		var rendererWidth = renderer.context.drawingBufferWidth;
-		var rendererHeight = renderer.context.drawingBufferHeight;
+		var rendererWidth = renderer.context.drawingBufferWidth / renderer.getPixelRatio();
+		var rendererHeight = renderer.context.drawingBufferHeight / renderer.getPixelRatio();
 		var eyeDivisionLine = rendererWidth / 2;
 
 		renderer.enableScissorTest( true );


### PR DESCRIPTION
Hi Boris, thanks for a great boilerplate!

From the release notes of [three.js r70](https://plus.google.com/+ricardocabello/posts/VGg2KQQ5zXy), developers should add

``` javascript
renderer.setPixelRatio( window.devicePixelRatio );
```

to still be able to get a nice resolution on devices that not has a pixel ratio of 1, for example a MacBook retina or some smartphone. The resolution difference is most apparent when using a Cardboard setup.
Unfortunately, this line causes a glitch in VREffect.js, which is fixed in this [merged PR](https://github.com/mrdoob/three.js/pull/6248) in the dev branch of threejs.

Best,
Niklas
