### PR TITLE
Hide back arrow in Firefox

### DIFF
--- a/src/button-manager.js
+++ b/src/button-manager.js
@@ -116,7 +116,9 @@ ButtonManager.prototype.setMode = function(mode, isVRCompatible) {
     case Modes.VR:
       this.fsButton.style.display = 'none';
       this.vrButton.style.display = 'none';
-      this.backButton.style.display = Util.isMobile() ? 'block' : 'none';
+      // Hack for Firefox, since it doesn't display HTML content correctly in
+      // VR at the moment.
+      this.backButton.style.display = Util.isFirefox() ? 'none' : 'block';
       break;
   }
 

--- a/src/button-manager.js
+++ b/src/button-manager.js
@@ -116,7 +116,7 @@ ButtonManager.prototype.setMode = function(mode, isVRCompatible) {
     case Modes.VR:
       this.fsButton.style.display = 'none';
       this.vrButton.style.display = 'none';
-      this.backButton.style.display = 'block';
+      this.backButton.style.display = Util.isMobile() ? 'block' : 'none';
       break;
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -25,6 +25,10 @@ Util.isMobile = function() {
   return check;
 };
 
+Util.isFirefox = function() {
+  return /firefox/i.test(navigator.userAgent);
+};
+
 Util.isIOS = function() {
   return /(iPad|iPhone|iPod)/g.test(navigator.userAgent);
 };


### PR DESCRIPTION
Firefox Nightly doesn't render HTML content correctly at the moment. It shows the back arrow enlarged in the bottom right of the right eye in the DK2. This PR hides the arrow for desktop devices.
