### PR TITLE
Re-enable depth buffer on render target

### DIFF
--- a/build/webvr-manager.js
+++ b/build/webvr-manager.js
@@ -258,8 +258,7 @@ function createRenderTarget(renderer) {
   var parameters = {minFilter: THREE.LinearFilter,
                     magFilter: THREE.LinearFilter,
                     format: THREE.RGBFormat,
-                    stencilBuffer: false,
-                    depthBuffer: false};
+                    stencilBuffer: false};
 
   return new THREE.WebGLRenderTarget(width, height, parameters);
 }

--- a/src/cardboard-distorter.js
+++ b/src/cardboard-distorter.js
@@ -98,8 +98,7 @@ function createRenderTarget(renderer) {
   var parameters = {minFilter: THREE.LinearFilter,
                     magFilter: THREE.LinearFilter,
                     format: THREE.RGBFormat,
-                    stencilBuffer: false,
-                    depthBuffer: false};
+                    stencilBuffer: false};
 
   return new THREE.WebGLRenderTarget(width, height, parameters);
 }


### PR DESCRIPTION
This reverts commit 5c6f9d789689d1b6eba0e09151de8fc265c5f0a3.

Fixes #55
Reverts #35

It's not a good idea, because it disables depth buffer in the original scene.

@zazabe @mrdoob fyi
