### PR TITLE
added configurable parentElem and preventButton

### DIFF
--- a/build/webvr-manager.js
+++ b/build/webvr-manager.js
@@ -1246,6 +1246,7 @@ function WebVRManager(renderer, effect, params) {
   // Set option to hide the button.
   var hideButton = this.params.hideButton || false;
 
+  this.parentEl = params.parentEl instanceof Element ? params.parentEl : document.body;
   this.deviceInfo = new DeviceInfo();
 
   // Save the THREE.js renderer and effect for later.
@@ -1530,17 +1531,24 @@ WebVRManager.prototype.anyModeToNormal_ = function() {
 };
 
 WebVRManager.prototype.resizeIfNeeded_ = function(camera) {
+ var size = this.renderer.getSize(),
+     elem = this.parentEl,
+     width = elem.offsetWidth,
+     height = elem.offsetHeight;
+  
   // Only resize the canvas if it needs to be resized.
   var size = this.renderer.getSize();
-  if (size.width != window.innerWidth || size.height != window.innerHeight) {
+  if (size.width != width || size.height != height) {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
-    this.resize_()
+    this.resize_();
   }
 };
 
 WebVRManager.prototype.resize_ = function() {
-  this.effect.setSize(window.innerWidth, window.innerHeight);
+ var elem = this.getParentElem_();
+ 
+  this.effect.setSize(elem.offsetWidth, elem.offsetHeight);
 };
 
 WebVRManager.prototype.onOrientationChange_ = function(e) {

--- a/src/webvr-manager.js
+++ b/src/webvr-manager.js
@@ -338,17 +338,16 @@ WebVRManager.prototype.resizeIfNeeded_ = function(camera) {
      height = elem.offsetHeight;
   
   // Only resize the canvas if it needs to be resized.
-  var size = this.renderer.getSize();
   if (size.width != width || size.height != height) {
-    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.aspect = width / height;
     camera.updateProjectionMatrix();
     this.resize_();
   }
 };
 
 WebVRManager.prototype.resize_ = function() {
- var elem = this.getParentElem_();
- 
+  var elem = this.parentEl;
+
   this.effect.setSize(elem.offsetWidth, elem.offsetHeight);
 };
 

--- a/src/webvr-manager.js
+++ b/src/webvr-manager.js
@@ -47,6 +47,7 @@ function WebVRManager(renderer, effect, params) {
   // Set option to hide the button.
   var hideButton = this.params.hideButton || false;
 
+  this.parentEl = params.parentEl instanceof Element ? params.parentEl : document.body;
   this.deviceInfo = new DeviceInfo();
 
   // Save the THREE.js renderer and effect for later.
@@ -331,17 +332,24 @@ WebVRManager.prototype.anyModeToNormal_ = function() {
 };
 
 WebVRManager.prototype.resizeIfNeeded_ = function(camera) {
+ var size = this.renderer.getSize(),
+     elem = this.parentEl,
+     width = elem.offsetWidth,
+     height = elem.offsetHeight;
+  
   // Only resize the canvas if it needs to be resized.
   var size = this.renderer.getSize();
-  if (size.width != window.innerWidth || size.height != window.innerHeight) {
+  if (size.width != width || size.height != height) {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
-    this.resize_()
+    this.resize_();
   }
 };
 
 WebVRManager.prototype.resize_ = function() {
-  this.effect.setSize(window.innerWidth, window.innerHeight);
+ var elem = this.getParentElem_();
+ 
+  this.effect.setSize(elem.offsetWidth, elem.offsetHeight);
 };
 
 WebVRManager.prototype.onOrientationChange_ = function(e) {


### PR DESCRIPTION
added configurable parentElem and preventButton

https://github.com/borismus/webvr-boilerplate/issues/68
https://github.com/borismus/webvr-boilerplate/issues/66

if defined, `parentElem` is used in place of window to obtain width and height. `preventButton` prevents button construction.

``` javascript
    var manager = new WebVRManager(renderer, effect, {
      parentElem : videoElem.parentNode,
      preventButton : true
    });
```
