### PR TITLE
Add app manifest.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<link rel="manifest" href="/manifest.json">
 <style>
 body {
   width: 100%;

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "short_name": "WebVR Boilerplate",
+  "name": "WebVR Boilerplate",
+  "start_url": "/index.html",
+  "display": "fullscreen",
+  "orientation": "landscape"
+}


### PR DESCRIPTION
This makes it possible to directly install the VR app to your homescreen on your mobile device, supported in e.g. Chrome. I tested that this works fine on an Android device.

For more about the App Manifest, see [https://developer.mozilla.org/en-US/docs/Web/Manifest](this).
