### PR TITLE
Declare non-constant fragment shader variables inside main

### DIFF
--- a/src/distortion/barrel-distortion-fragment-v2.js
+++ b/src/distortion/barrel-distortion-fragment-v2.js
@@ -33,12 +33,6 @@ var BarrelDistortionFragment = {
     'uniform int showCenter;',
     'uniform vec4 dividerColor;',
 
-    // right projections are shifted and vertically mirrored relative to left
-    'vec4 projectionRight = ',
-    '(projectionLeft + vec4(0.0, 0.0, 1.0, 0.0)) * vec4(1.0, 1.0, -1.0, 1.0);',
-    'vec4 unprojectionRight = ',
-    '(unprojectionLeft + vec4(0.0, 0.0, 1.0, 0.0)) * vec4(1.0, 1.0, -1.0, 1.0);',
-
     'varying vec2 vUV;',
 
     'float poly(float val) {',
@@ -52,6 +46,12 @@ var BarrelDistortionFragment = {
     '}',
 
     'void main() {',
+      // right projections are shifted and vertically mirrored relative to left
+      'vec4 projectionRight = ',
+      '(projectionLeft + vec4(0.0, 0.0, 1.0, 0.0)) * vec4(1.0, 1.0, -1.0, 1.0);',
+      'vec4 unprojectionRight = ',
+      '(unprojectionLeft + vec4(0.0, 0.0, 1.0, 0.0)) * vec4(1.0, 1.0, -1.0, 1.0);',
+
       'vec2 a = (vUV.x < 0.5) ? ',
       'barrel(vec2(vUV.x / 0.5, vUV.y), projectionLeft, unprojectionLeft) : ',
       'barrel(vec2((vUV.x - 0.5) / 0.5, vUV.y), projectionRight, unprojectionRight);',


### PR DESCRIPTION
I'm getting the following warning in Chrome when compiling the BarrelDistortionFragment (v2) shader:

`WARNING: 0:22: '=' : global variable initializers should be constant expressions (uniforms and globals are allowed in global initializers for legacy compatibility)`

It's on the declaration of `projectionRight` and `unprojectionRight`. If you move those declarations inside of `main`, the warning goes away. I'm not sure, but I suspect this might break on certain devices. There's some discussion of it and a proper reference to the spec [on Stack Overflow](http://stackoverflow.com/questions/28076568/is-it-ever-reasonable-to-do-computations-outside-of-main-in-an-opengl-shader).
