### PR TITLE
Fix Nexus 6 physical dimensions.

### DIFF
--- a/src/device-info.js
+++ b/src/device-info.js
@@ -81,8 +81,8 @@ var AndroidDevices = {
   }),
   Nexus6: new Device({
     userAgentRegExp: /Nexus 6 /, // Trailing space to disambiguate from 6P.
-    widthMeters: 0.1593,
-    heightMeters: 0.083,
+    widthMeters: 0.1320,
+    heightMeters: 0.074,
     bevelMeters: 0.004
   }),
   Nexus5X: new Device({


### PR DESCRIPTION
Fix Nexus 6 device dimensions.

The correct distance between the eye centers for the Google I/O 2015 Cardboard viewer is 63mm. With the current Nexus 6 measurements, they are being rendered 52mm apart. With this fix in this pull request, the distance is now corrected to 63mm.
