### PR TITLE
use device params provided by browser/WebVR API if not using polyfill

### DIFF
--- a/src/webvr-manager.js
+++ b/src/webvr-manager.js
@@ -471,7 +471,10 @@ WebVRManager.prototype.setHMDVRDeviceParams_ = function(viewer) {
     if (!hmd) {
       return;
     }
-
+    if (hmd.deviceName.indexOf('webvr-polyfill') === -1) {
+      // webvr-polyfill not in use, assume params are provided by browser/WebVR API
+      return;
+    }
     // If we can set fields of view, do that now.
     if (hmd.setFieldOfView) {
       // Calculate the optimal field of view for each eye.

--- a/src/webvr-manager.js
+++ b/src/webvr-manager.js
@@ -473,7 +473,8 @@ WebVRManager.prototype.setHMDVRDeviceParams_ = function(viewer) {
       return;
     }
     if (hmd.deviceName.indexOf('webvr-polyfill') === -1) {
-      // webvr-polyfill not in use, assume params are provided by browser/WebVR API
+      // The HMDVRDevice is not provided by WebVR Polyfill,
+      // so we assume the browser implements WebVR and has taken care of setting parameters.
       return;
     }
     // If we can set fields of view, do that now.


### PR DESCRIPTION
Recently I've experienced weird VR mode when using webvr-boilerplate with Oculus DK2 in WebVR enabled Firefox Nightly or Chromium (fov looks too large or something).  I think it has something to do with setHMDVRDevice parameters setting properties of the non-polyfill HMDVRDevice, which shouldn't be necessary such cases.
