### PR TITLE
IE11 fullscreen fix

### DIFF
--- a/build/webvr-manager.js
+++ b/build/webvr-manager.js
@@ -2595,6 +2595,8 @@ function WebVRManager(renderer, effect, params) {
       this.onFullscreenChange_.bind(this));
   document.addEventListener('mozfullscreenchange',
       this.onFullscreenChange_.bind(this));
+  document.addEventListener('MSFullscreenChange',
+      this.onFullscreenChange_.bind(this));
   window.addEventListener('orientationchange',
       this.onOrientationChange_.bind(this));
 
@@ -2900,6 +2902,8 @@ WebVRManager.prototype.requestFullscreen_ = function() {
     canvas.mozRequestFullScreen({vrDisplay: this.hmd});
   } else if (canvas.webkitRequestFullscreen) {
     canvas.webkitRequestFullscreen({vrDisplay: this.hmd});
+  } else if (canvas.msRequestFullscreen) {
+    canvas.msRequestFullscreen({vrDisplay: this.hmd});
   }
 };
 
@@ -2910,6 +2914,8 @@ WebVRManager.prototype.exitFullscreen_ = function() {
     document.mozCancelFullScreen();
   } else if (document.webkitExitFullscreen) {
     document.webkitExitFullscreen();
+  } else if (document.msExitFullscreen) {
+    document.msExitFullscreen();
   }
 };
 

--- a/src/webvr-manager.js
+++ b/src/webvr-manager.js
@@ -136,6 +136,8 @@ function WebVRManager(renderer, effect, params) {
       this.onFullscreenChange_.bind(this));
   document.addEventListener('mozfullscreenchange',
       this.onFullscreenChange_.bind(this));
+  document.addEventListener('MSFullscreenChange',
+      this.onFullscreenChange_.bind(this));
   window.addEventListener('orientationchange',
       this.onOrientationChange_.bind(this));
 
@@ -441,6 +443,8 @@ WebVRManager.prototype.requestFullscreen_ = function() {
     canvas.mozRequestFullScreen({vrDisplay: this.hmd});
   } else if (canvas.webkitRequestFullscreen) {
     canvas.webkitRequestFullscreen({vrDisplay: this.hmd});
+  } else if (canvas.msRequestFullscreen) {
+    canvas.msRequestFullscreen({vrDisplay: this.hmd});
   }
 };
 
@@ -451,6 +455,8 @@ WebVRManager.prototype.exitFullscreen_ = function() {
     document.mozCancelFullScreen();
   } else if (document.webkitExitFullscreen) {
     document.webkitExitFullscreen();
+  } else if (document.msExitFullscreen) {
+    document.msExitFullscreen();
   }
 };
 


### PR DESCRIPTION
Fixes the fullscreen buttons for IE11, which has its own set of prefixes:
- [Entering fullscreen](https://msdn.microsoft.com/en-us/library/dn254939%28v=vs.85%29.aspx)
- [Fullscreen change event](https://msdn.microsoft.com/en-us/library/dn312066%28v=vs.85%29.aspx)
- [Exiting fullscreen](https://msdn.microsoft.com/en-us/library/dn254936%28v=vs.85%29.aspx)

IE versions before and after 11 shouldn't be affected.
