### PR TITLE
fix for buttons not being visible depending on box model

### DIFF
--- a/src/button-manager.js
+++ b/src/button-manager.js
@@ -69,6 +69,7 @@ ButtonManager.prototype.createButton = function() {
   s.padding = '12px';
   s.zIndex = 1;
   s.display = 'none';
+  s.boxSizing = 'content-box';
 
   // Prevent button from being selected and dragged.
   button.draggable = false;


### PR DESCRIPTION
if the page hosting webvr-manager uses box-sizing: border-box (which everyone should! :D) the buttons are not visible. this fix makes sure that at least is reset, but there might be other combinations of css rules that affect how the button is rendered
